### PR TITLE
Bookings UI, auth fixes, and showtime/cancel guards

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env and fill in values:
+#   cp .env.example .env
+
+# Required: Neon (or other Postgres) connection string — use pooled URI from Neon dashboard.
+DATABASE_URL=
+
+# Optional (defaults shown in code if unset):
+# JWT_SECRET=dev-secret-change-me
+# AUTH_TOKEN_TTL_MINUTES=1440
+# PORT=8080

--- a/backend/db/migrations/003_create_movies.sql
+++ b/backend/db/migrations/003_create_movies.sql
@@ -37,7 +37,7 @@ VALUES
         128,
         '2024-06-14',
         8.4,
-        'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg',
+        'https://placehold.co/500x750/0c1222/7dd3fc/png?text=Starlight+Horizon',
         TRUE,
         NOW(),
         NOW()
@@ -51,7 +51,7 @@ VALUES
         112,
         '2023-11-03',
         7.6,
-        'https://example.com/posters/monsoon-diaries.jpg',
+        'https://placehold.co/500x750/0f1f1a/86efac/png?text=Monsoon+Diaries',
         TRUE,
         NOW(),
         NOW()
@@ -65,7 +65,7 @@ VALUES
         121,
         '2024-02-09',
         8.1,
-        'https://image.tmdb.org/t/p/w500/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg',
+        'https://placehold.co/500x750/1a0f14/fbcfe8/png?text=The+Last+Ticket',
         TRUE,
         NOW(),
         NOW()

--- a/backend/db/migrations/005_update_movie_poster_urls.sql
+++ b/backend/db/migrations/005_update_movie_poster_urls.sql
@@ -1,15 +1,15 @@
--- Replace placeholder example.com poster URLs with working TMDB CDN URLs.
+-- Posters that match seeded titles (fictional movies; TMDB IDs were unrelated films).
 UPDATE movies
-SET poster_url = 'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg',
+SET poster_url = 'https://placehold.co/500x750/0c1222/7dd3fc/png?text=Starlight+Horizon',
     updated_at = NOW()
 WHERE id = 'mov_001';
 
 UPDATE movies
-SET poster_url = 'https://image.tmdb.org/t/p/w500/q6y0Go1tsGEsmtFryDOJo3dEmqu.jpg',
+SET poster_url = 'https://placehold.co/500x750/0f1f1a/86efac/png?text=Monsoon+Diaries',
     updated_at = NOW()
 WHERE id = 'mov_002';
 
 UPDATE movies
-SET poster_url = 'https://image.tmdb.org/t/p/w500/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg',
+SET poster_url = 'https://placehold.co/500x750/1a0f14/fbcfe8/png?text=The+Last+Ticket',
     updated_at = NOW()
 WHERE id = 'mov_003';

--- a/backend/internal/database/postgres.go
+++ b/backend/internal/database/postgres.go
@@ -265,7 +265,7 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 			128,
 			'2024-06-14',
 			8.4,
-			'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg',
+			'https://placehold.co/500x750/0c1222/7dd3fc/png?text=Starlight+Horizon',
 			TRUE,
 			NOW(),
 			NOW()
@@ -279,7 +279,7 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 			112,
 			'2023-11-03',
 			7.6,
-			'https://image.tmdb.org/t/p/w500/q6y0Go1tsGEsmtFryDOJo3dEmqu.jpg',
+			'https://placehold.co/500x750/0f1f1a/86efac/png?text=Monsoon+Diaries',
 			TRUE,
 			NOW(),
 			NOW()
@@ -293,7 +293,7 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 			121,
 			'2024-02-09',
 			8.1,
-			'https://image.tmdb.org/t/p/w500/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg',
+			'https://placehold.co/500x750/1a0f14/fbcfe8/png?text=The+Last+Ticket',
 			TRUE,
 			NOW(),
 			NOW()
@@ -303,6 +303,23 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 
 	if _, err := db.ExecContext(ctx, seedMoviesQuery); err != nil {
 		return err
+	}
+
+	patchPosters := []struct {
+		id  string
+		url string
+	}{
+		{"mov_001", "https://placehold.co/500x750/0c1222/7dd3fc/png?text=Starlight+Horizon"},
+		{"mov_002", "https://placehold.co/500x750/0f1f1a/86efac/png?text=Monsoon+Diaries"},
+		{"mov_003", "https://placehold.co/500x750/1a0f14/fbcfe8/png?text=The+Last+Ticket"},
+	}
+	for _, p := range patchPosters {
+		if _, err := db.ExecContext(ctx,
+			`UPDATE movies SET poster_url = $2, updated_at = NOW() WHERE id = $1`,
+			p.id, p.url,
+		); err != nil {
+			return err
+		}
 	}
 
 	seedTheatersQuery := `

--- a/backend/internal/handler/booking_handler.go
+++ b/backend/internal/handler/booking_handler.go
@@ -101,6 +101,9 @@ func handleBookingError(w http.ResponseWriter, err error) {
 	case errors.Is(err, repository.ErrShowtimeNotFound):
 		response.Error(w, http.StatusNotFound, "showtime not found", nil)
 		return
+	case errors.Is(err, repository.ErrShowtimeStarted):
+		response.Error(w, http.StatusBadRequest, "this showtime has already started", nil)
+		return
 	case errors.Is(err, repository.ErrHoldNotFound):
 		response.Error(w, http.StatusNotFound, "booking hold not found", nil)
 		return

--- a/backend/internal/repository/booking_repository.go
+++ b/backend/internal/repository/booking_repository.go
@@ -20,6 +20,7 @@ var (
 	ErrBookingNotOwned         = errors.New("booking does not belong to the requesting user")
 	ErrDuplicatePayment        = errors.New("duplicate payment for this idempotency key")
 	ErrPaymentNotFound         = errors.New("payment transaction not found")
+	ErrShowtimeStarted         = errors.New("showtime has already started")
 )
 
 type BookingRepository interface {

--- a/backend/internal/repository/postgres/booking_repository.go
+++ b/backend/internal/repository/postgres/booking_repository.go
@@ -48,15 +48,20 @@ func (r *BookingRepository) CreateHold(ctx context.Context, input domain.CreateB
 	defer tx.Rollback()
 
 	var basePrice float64
+	var showStart time.Time
 	if err := tx.QueryRowContext(
 		ctx,
-		`SELECT base_price FROM showtimes WHERE id = $1 AND is_active = TRUE`,
+		`SELECT base_price, start_time FROM showtimes WHERE id = $1 AND is_active = TRUE`,
 		input.ShowtimeID,
-	).Scan(&basePrice); err != nil {
+	).Scan(&basePrice, &showStart); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.BookingHold{}, repository.ErrShowtimeNotFound
 		}
 		return domain.BookingHold{}, err
+	}
+
+	if !showStart.After(time.Now().UTC()) {
+		return domain.BookingHold{}, repository.ErrShowtimeStarted
 	}
 
 	seatState := make(map[string]struct {
@@ -396,12 +401,16 @@ func (r *BookingRepository) CancelBooking(ctx context.Context, bookingID string,
 
 	var status string
 	var holdID string
-	var showtimeID string
+	var showStart time.Time
 
 	err = tx.QueryRowContext(ctx,
-		`SELECT status, hold_id, showtime_id FROM bookings WHERE id = $1 AND user_id = $2 FOR UPDATE`,
+		`SELECT b.status, b.hold_id, s.start_time
+		 FROM bookings b
+		 JOIN showtimes s ON s.id = b.showtime_id
+		 WHERE b.id = $1 AND b.user_id = $2
+		 FOR UPDATE OF b`,
 		bookingID, userID,
-	).Scan(&status, &holdID, &showtimeID)
+	).Scan(&status, &holdID, &showStart)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return repository.ErrBookingNotFound
@@ -414,6 +423,9 @@ func (r *BookingRepository) CancelBooking(ctx context.Context, bookingID string,
 	}
 
 	now := time.Now().UTC()
+	if !showStart.After(now) {
+		return repository.ErrShowtimeStarted
+	}
 
 	// Cancel the booking
 	if _, err := tx.ExecContext(ctx,

--- a/backend/internal/repository/postgres/movie_repository.go
+++ b/backend/internal/repository/postgres/movie_repository.go
@@ -183,6 +183,7 @@ func (r *MovieRepository) ListMovieShowtimeRecords(ctx context.Context, movieID 
 	  AND t.is_active = TRUE
 	  AND s.is_active = TRUE
 	  AND (s.start_time AT TIME ZONE 'America/New_York')::date >= (NOW() AT TIME ZONE 'America/New_York')::date
+	  AND s.start_time > NOW()
 	`
 
 	args := []any{strings.TrimSpace(movieID)}

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -75,7 +75,7 @@ func (s *AuthService) Signup(ctx context.Context, input domain.SignupInput) (dom
 	user := domain.User{
 		ID:           fmt.Sprintf("usr_%d", time.Now().UnixNano()),
 		Name:         strings.TrimSpace(input.Name),
-		Phone:        strings.TrimSpace(input.Phone),
+		Phone:        validation.NormalizePhone(input.Phone),
 		Email:        strings.ToLower(strings.TrimSpace(input.Email)),
 		PasswordHash: string(hashedPassword),
 		IsAdmin:      false,

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -130,6 +130,31 @@ func TestAuthServiceSignup_Success(t *testing.T) {
 	if user.ID == "" || user.Email != "dinesh@example.com" {
 		t.Fatalf("unexpected user created: %+v", user)
 	}
+	if user.Phone != "1234567890" {
+		t.Fatalf("expected normalized phone, got %q", user.Phone)
+	}
+}
+
+func TestAuthServiceSignup_StoresNormalizedFormattedPhone(t *testing.T) {
+	svc := NewAuthService(&authUserRepoStub{
+		createFn: func(_ context.Context, user domain.User) (domain.User, error) {
+			return user, nil
+		},
+	})
+
+	user, validationErrs, err := svc.Signup(context.Background(), domain.SignupInput{
+		Name:            "Dinesh",
+		Phone:           "+1 (555) 123-4567",
+		Email:           "dinesh@example.com",
+		Password:        "password123",
+		ConfirmPassword: "password123",
+	})
+	if err != nil || len(validationErrs) != 0 {
+		t.Fatalf("signup failed: err=%v errs=%v", err, validationErrs)
+	}
+	if user.Phone != "15551234567" {
+		t.Fatalf("expected digits-only phone, got %q", user.Phone)
+	}
 }
 
 func TestAuthServiceLogin_UserNotFound(t *testing.T) {

--- a/backend/internal/validation/signup_validation.go
+++ b/backend/internal/validation/signup_validation.go
@@ -2,26 +2,38 @@ package validation
 
 import (
 	"net/mail"
-	"regexp"
 	"strings"
+	"unicode"
 
 	"box-office-go/backend/internal/domain"
 )
 
-var phoneRegex = regexp.MustCompile(`^[0-9+]{8,15}$`)
+// NormalizePhone strips formatting; keeps digits only (E.164-style input with +, spaces, dashes, etc.).
+func NormalizePhone(raw string) string {
+	var b strings.Builder
+	for _, r := range raw {
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
 
 func ValidateSignupInput(input domain.SignupInput) map[string]string {
 	errors := make(map[string]string)
 
-	if strings.TrimSpace(input.Name) == "" {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
 		errors["name"] = "name is required"
+	} else if len(name) < 2 {
+		errors["name"] = "name must be at least 2 characters"
 	}
 
-	phone := strings.TrimSpace(input.Phone)
+	phone := NormalizePhone(input.Phone)
 	if phone == "" {
 		errors["phone"] = "phone is required"
-	} else if !phoneRegex.MatchString(phone) {
-		errors["phone"] = "phone must be 8-15 chars and only digits/+"
+	} else if len(phone) < 8 || len(phone) > 15 {
+		errors["phone"] = "phone must be 8-15 digits (country code included)"
 	}
 
 	email := strings.TrimSpace(input.Email)

--- a/backend/internal/validation/signup_validation_test.go
+++ b/backend/internal/validation/signup_validation_test.go
@@ -21,10 +21,34 @@ func TestValidateSignupInput_Success(t *testing.T) {
 	}
 }
 
+func TestValidateSignupInput_FormattedPhoneAccepted(t *testing.T) {
+	input := domain.SignupInput{
+		Name:            "Dinesh",
+		Phone:           "+1 (555) 123-4567",
+		Email:           "dinesh@example.com",
+		Password:        "password123",
+		ConfirmPassword: "password123",
+	}
+
+	errs := ValidateSignupInput(input)
+	if len(errs) != 0 {
+		t.Fatalf("expected formatted phone to normalize cleanly, got %v", errs)
+	}
+}
+
+func TestNormalizePhone(t *testing.T) {
+	if got := NormalizePhone("+1 (555) 123-4567"); got != "15551234567" {
+		t.Fatalf("got %q", got)
+	}
+	if got := NormalizePhone("  +91 98765 43210 "); got != "919876543210" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestValidateSignupInput_InvalidFields(t *testing.T) {
 	input := domain.SignupInput{
-		Name:            "  ",
-		Phone:           "abc",
+		Name:            "a",
+		Phone:           "1234567",
 		Email:           "not-an-email",
 		Password:        "short",
 		ConfirmPassword: "different",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -442,6 +442,7 @@
       "version": "21.1.4",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.1.4.tgz",
       "integrity": "sha512-1uOxPrHO9PFZBU/JavzYzjxAm+5x7vD2z6AeUndqdT4LjqOBIePswxFDRqM9dlfF8FIwnnfmNFipiC/yQjJSnA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -457,6 +458,7 @@
       "version": "21.1.4",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.1.4.tgz",
       "integrity": "sha512-H0qtASeqOTaS44ioF4DYE/yNqwzUmEJpMYrcNEUFEwA20/DkLzyoaEx4y1CjIxtXxuhtge95PNymDBOLWSjIdg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -469,6 +471,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.1.4.tgz",
       "integrity": "sha512-Uw8KmpVCo58/f5wf6pY8ZS5fodv65hn5jxms8Nv/K7/LVe3i1nNFrHyneBx5+a7qkz93nSV4rdwBVnMvjIyr+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -500,6 +503,7 @@
       "version": "21.1.4",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.1.4.tgz",
       "integrity": "sha512-QBDO5SaVYTVQ0fIN9Qd7US9cUCgs2vM9x6K18PTUKmygIkHVHTFdzwm4MO5gpCOFzJseGbS+dNzqn+v0PaKf9g==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -542,6 +546,7 @@
       "version": "21.1.4",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.1.4.tgz",
       "integrity": "sha512-S6Iw5CkORih5omh+MQY35w0bUBxdSFAPLDg386S6/9fEUjDClo61hvXNKxaNh9g7tnh1LD7zmTmKrqufnhnFDQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -654,6 +659,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -982,6 +988,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1020,6 +1027,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1823,6 +1831,7 @@
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -3772,16 +3781,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
@@ -4319,6 +4318,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4508,6 +4508,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -5856,6 +5857,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6370,6 +6372,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6828,6 +6831,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -6966,6 +6970,7 @@
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -8357,6 +8362,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9082,7 +9088,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -9144,6 +9151,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9162,10 +9170,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/unique-filename": {
@@ -9305,6 +9314,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9379,6 +9389,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9763,6 +9774,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -5,6 +5,7 @@
   </a>
   <nav class="auth-nav">
     @if (auth.isLoggedInSignal()) {
+      <a routerLink="/bookings" class="btn btn-ghost" routerLinkActive="active-nav">My bookings</a>
       <button type="button" class="btn btn-ghost" (click)="auth.logout()">Log out</button>
     } @else {
       <a routerLink="/login" class="btn btn-ghost">Sign in</a>
@@ -107,6 +108,11 @@
   .auth-nav .btn-ghost:active {
     transform: translateY(0);
   }
+  .auth-nav a.btn.active-nav {
+    color: #fff;
+    background: rgba(167, 139, 250, 0.2);
+    border-color: rgba(167, 139, 250, 0.35);
+  }
 </style>
 
 <style>
@@ -119,4 +125,5 @@
   }
 </style>
 
+<app-toast />
 <router-outlet />

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,10 +1,17 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   {
     path: '',
     loadComponent: () =>
       import('./pages/home/home.component').then(m => m.HomeComponent)
+  },
+  {
+    path: 'bookings',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./pages/my-bookings/my-bookings.component').then(m => m.MyBookingsComponent)
   },
   {
     path: 'movies/:movieId/seats',

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component, signal } from '@angular/core';
-import { RouterOutlet, RouterLink } from '@angular/router';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from './services/auth.service';
+import { ToastComponent } from './components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, ToastComponent],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/frontend/src/app/components/toast/toast.component.ts
+++ b/frontend/src/app/components/toast/toast.component.ts
@@ -1,0 +1,49 @@
+import { Component, inject } from '@angular/core';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  template: `
+    @if (toast.message(); as msg) {
+      <div class="toast" role="status" aria-live="polite">{{ msg }}</div>
+    }
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+    .toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10000;
+      max-width: min(420px, calc(100vw - 2rem));
+      padding: 0.75rem 1.25rem;
+      border-radius: 12px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #f0fdf4;
+      background: linear-gradient(135deg, rgba(22, 101, 52, 0.95), rgba(21, 128, 61, 0.92));
+      border: 1px solid rgba(134, 239, 172, 0.45);
+      box-shadow:
+        0 12px 40px rgba(0, 0, 0, 0.35),
+        0 0 0 1px rgba(255, 255, 255, 0.06) inset;
+      animation: toast-in 0.22s ease-out;
+    }
+    @keyframes toast-in {
+      from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(12px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
+    }
+  `
+})
+export class ToastComponent {
+  readonly toast = inject(ToastService);
+}

--- a/frontend/src/app/core/guards/auth.guard.ts
+++ b/frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { Router, type CanActivateFn } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isLoggedIn()) {
+    return true;
+  }
+  return router.createUrlTree(['/login'], { queryParams: { from: 'bookings' } });
+};

--- a/frontend/src/app/pages/auth/login/login.component.ts
+++ b/frontend/src/app/pages/auth/login/login.component.ts
@@ -33,6 +33,10 @@ export class LoginComponent {
         this.signInMessage = 'Account created. Please sign in.';
       } else if (params['from'] === 'see-all-movies') {
         this.signInMessage = 'Sign in to browse the full movie catalog.';
+      } else if (params['from'] === 'booking') {
+        this.signInMessage = 'Sign in to continue booking your seats.';
+      } else if (params['from'] === 'bookings') {
+        this.signInMessage = 'Sign in to view your bookings.';
       } else {
         this.signInMessage = '';
       }
@@ -70,6 +74,10 @@ export class LoginComponent {
           } catch {
             // If parsing fails, fall back to default behavior.
           }
+        }
+        if (this.route.snapshot.queryParamMap.get('from') === 'bookings') {
+          void this.router.navigate(['/bookings']);
+          return;
         }
         void this.router.navigate(['/']);
       },

--- a/frontend/src/app/pages/auth/signup/signup.component.html
+++ b/frontend/src/app/pages/auth/signup/signup.component.html
@@ -18,7 +18,7 @@
       <span>Phone</span>
       <input type="tel" formControlName="phone" placeholder="+919876543210" autocomplete="tel" />
       @if (form.get('phone')?.invalid && form.get('phone')?.touched) {
-        <span class="field-error">8–15 digits, optional leading +</span>
+        <span class="field-error">8–15 digits (spaces, dashes, and + are OK)</span>
       }
     </label>
     <label>

--- a/frontend/src/app/pages/auth/signup/signup.component.ts
+++ b/frontend/src/app/pages/auth/signup/signup.component.ts
@@ -21,6 +21,23 @@ function passwordsMatchValidator(group: AbstractControl): ValidationErrors | nul
   return p === c ? null : { passwordMismatch: true };
 }
 
+/** Digits only; matches backend NormalizePhone. */
+function normalizePhoneDigits(raw: string): string {
+  return raw.replace(/\D/g, '');
+}
+
+function phoneDigitsValidator(control: AbstractControl): ValidationErrors | null {
+  const raw = (control.value as string) ?? '';
+  if (!raw.trim()) {
+    return null;
+  }
+  const digits = normalizePhoneDigits(raw);
+  if (digits.length < 8 || digits.length > 15) {
+    return { phoneDigits: true };
+  }
+  return null;
+}
+
 @Component({
   selector: 'app-signup',
   standalone: true,
@@ -41,7 +58,7 @@ export class SignupComponent {
     this.form = this.fb.nonNullable.group(
       {
         name: ['', [Validators.required, Validators.minLength(2)]],
-        phone: ['', [Validators.required, Validators.pattern(/^[0-9+]{8,15}$/)]],
+        phone: ['', [Validators.required, phoneDigitsValidator]],
         email: ['', [Validators.required, Validators.email]],
         password: ['', [Validators.required, Validators.minLength(8)]],
         confirmPassword: ['', Validators.required]
@@ -58,11 +75,12 @@ export class SignupComponent {
     this.error = '';
     this.loading = true;
     const v = this.form.getRawValue();
+    const email = v.email.trim();
     this.auth
       .signup({
-        name: v.name,
-        phone: v.phone,
-        email: v.email,
+        name: v.name.trim(),
+        phone: normalizePhoneDigits(v.phone),
+        email,
         password: v.password,
         confirmPassword: v.confirmPassword
       })

--- a/frontend/src/app/pages/booking-success/booking-success.component.spec.ts
+++ b/frontend/src/app/pages/booking-success/booking-success.component.spec.ts
@@ -23,11 +23,14 @@ function createRouteStub() {
   } as any;
 }
 
+const toastStub = { show: vi.fn() };
+
 describe('BookingSuccessComponent', () => {
   it('parses booking route/query data on init', () => {
     const component = new BookingSuccessComponent(
       createRouteStub(),
-      { downloadTicket: vi.fn().mockReturnValue(of(new Blob(['pdf'], { type: 'application/pdf' }))) } as any
+      { downloadTicket: vi.fn().mockReturnValue(of(new Blob(['pdf'], { type: 'application/pdf' }))) } as any,
+      toastStub as any
     );
 
     expect(component.movieId()).toBe('mov_001');
@@ -39,7 +42,8 @@ describe('BookingSuccessComponent', () => {
   it('sets error when ticket download fails', () => {
     const component = new BookingSuccessComponent(
       createRouteStub(),
-      { downloadTicket: vi.fn().mockReturnValue(throwError(() => new Error('fail'))) } as any
+      { downloadTicket: vi.fn().mockReturnValue(throwError(() => new Error('fail'))) } as any,
+      toastStub as any
     );
 
     component.downloadTicket();

--- a/frontend/src/app/pages/booking-success/booking-success.component.ts
+++ b/frontend/src/app/pages/booking-success/booking-success.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { BookingService } from '../../services/booking.service';
+import { ToastService } from '../../services/toast.service';
 
 @Component({
   selector: 'app-booking-success',
@@ -21,7 +22,8 @@ export class BookingSuccessComponent {
 
   constructor(
     private route: ActivatedRoute,
-    private bookingService: BookingService
+    private bookingService: BookingService,
+    private toast: ToastService
   ) {
     this.route.paramMap.subscribe(pm => {
       this.movieId.set(pm.get('movieId') ?? '');
@@ -62,6 +64,7 @@ export class BookingSuccessComponent {
         anchor.click();
         anchor.remove();
         window.URL.revokeObjectURL(url);
+        this.toast.show('Ticket downloaded');
       },
       error: () => {
         this.downloading.set(false);

--- a/frontend/src/app/pages/home/home.component.html
+++ b/frontend/src/app/pages/home/home.component.html
@@ -86,7 +86,13 @@
   <section class="recommended-section">
     <div class="section-header">
       <h2 class="section-title">Recommended Movies</h2>
-      <a (click)="goToSignIn()" class="see-all-link">See All &gt;</a>
+      <button type="button" class="see-all-link" (click)="onSeeAllClick($event)">
+        @if (auth.isLoggedInSignal() && catalogExpanded()) {
+          Show less
+        } @else {
+          See All &gt;
+        }
+      </button>
     </div>
 
     <div class="movies-container">

--- a/frontend/src/app/pages/home/home.component.scss
+++ b/frontend/src/app/pages/home/home.component.scss
@@ -382,13 +382,18 @@
 }
 
 .see-all-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
   color: #333;
   text-decoration: none;
   font-weight: 500;
   font-size: 1rem;
   cursor: pointer;
+  text-align: right;
   transition: color 0.2s ease;
-  
+
   &:hover {
     color: #667eea;
   }

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, OnDestroy, signal, computed } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterLink } from '@angular/router';
 import { MovieService } from '../../services/movie.service';
+import { AuthService } from '../../services/auth.service';
 import { ApiMovie } from '../../models/movie.models';
 
 @Component({
@@ -12,9 +13,15 @@ import { ApiMovie } from '../../models/movie.models';
   styleUrl: './home.component.scss'
 })
 export class HomeComponent implements OnInit, OnDestroy {
+  private readonly router = inject(Router);
+  private readonly movieService = inject(MovieService);
+  readonly auth = inject(AuthService);
+
   currentHeroIndex = signal(0);
   currentMoviePage = signal(0);
   moviesPerPage = 5;
+  /** When signed in, "See All" expands the row instead of sending users to login. */
+  catalogExpanded = signal(false);
   private autoRotateInterval?: number;
 
   movies = signal<ApiMovie[]>([]);
@@ -23,17 +30,26 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   visibleMovies = computed(() => {
     const list = this.movies();
+    if (this.catalogExpanded()) {
+      return list;
+    }
     const start = this.currentMoviePage() * this.moviesPerPage;
     const end = start + this.moviesPerPage;
     return list.slice(start, end);
   });
 
   canGoNext = computed(() => {
+    if (this.catalogExpanded()) {
+      return false;
+    }
     const list = this.movies();
     return (this.currentMoviePage() + 1) * this.moviesPerPage < list.length;
   });
 
   canGoPrev = computed(() => {
+    if (this.catalogExpanded()) {
+      return false;
+    }
     return this.currentMoviePage() > 0;
   });
 
@@ -58,11 +74,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       emoji: '🎂💕'
     }
   ];
-
-  constructor(
-    private router: Router,
-    private movieService: MovieService
-  ) {}
 
   ngOnInit() {
     this.startAutoRotate();
@@ -161,7 +172,12 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
   }
 
-  goToSignIn() {
-    this.router.navigate(['/login'], { queryParams: { from: 'see-all-movies' } });
+  onSeeAllClick(event: Event) {
+    event.preventDefault();
+    if (this.auth.isLoggedIn()) {
+      this.catalogExpanded.update(v => !v);
+      return;
+    }
+    void this.router.navigate(['/login'], { queryParams: { from: 'see-all-movies' } });
   }
 }

--- a/frontend/src/app/pages/movie-seats/movie-seats.component.ts
+++ b/frontend/src/app/pages/movie-seats/movie-seats.component.ts
@@ -236,7 +236,6 @@ export class MovieSeatsComponent implements OnInit {
     this.holdInProgress.set(true);
     this.bookingService
       .createBookingHold({
-        userId: user.id,
         showtimeId: map.showtimeId,
         seatNumbers: selected
       })

--- a/frontend/src/app/pages/my-bookings/my-bookings.component.html
+++ b/frontend/src/app/pages/my-bookings/my-bookings.component.html
@@ -1,0 +1,82 @@
+<div class="bookings-page">
+  <nav class="page-nav">
+    <a routerLink="/" class="back-link">← Browse movies</a>
+  </nav>
+
+  <header class="page-header">
+    <h1>My bookings</h1>
+    <p class="lede">Confirmed tickets, downloads, and cancellations.</p>
+  </header>
+
+  @if (loading()) {
+    <p class="status" aria-busy="true">Loading your bookings…</p>
+  } @else if (listError()) {
+    <p class="status error" role="alert">{{ listError() }}</p>
+    <button type="button" class="retry-btn" (click)="loadBookings()">Try again</button>
+  } @else if (bookings().length === 0) {
+    <div class="empty-card">
+      <p>You don’t have any bookings yet.</p>
+      <a routerLink="/" class="cta-link">Find a showtime</a>
+    </div>
+  } @else {
+    @if (downloadError()) {
+      <p class="banner-error" role="alert">{{ downloadError() }}</p>
+    }
+    @if (cancelError()) {
+      <p class="banner-error" role="alert">{{ cancelError() }}</p>
+    }
+
+    <ul class="booking-list">
+      @for (b of bookings(); track b.bookingId) {
+        <li class="booking-card">
+          <div class="card-main">
+            <div class="title-row">
+              <h2>{{ b.movieTitle }}</h2>
+              <span class="status-pill" [class.status-pill--confirmed]="isConfirmed(b)" [class.status-pill--muted]="!isConfirmed(b)">
+                {{ b.status }}
+              </span>
+            </div>
+            <p class="theater-line">{{ b.theaterName }} · {{ b.city }}</p>
+            <p class="meta-line">
+              {{ formatWhen(b) }} · {{ b.screenName }} · {{ b.language }} · {{ b.format }}
+            </p>
+            <p class="meta-line">
+              <span class="label">Seats:</span> {{ b.seatNumbers.length ? b.seatNumbers.join(', ') : '—' }}
+            </p>
+            <p class="meta-line">
+              <span class="label">Total:</span> {{ b.totalAmount | currency: 'USD' }}
+            </p>
+            <p class="meta-line subtle">
+              <span class="label">Booked:</span> {{ formatConfirmed(b) }}
+            </p>
+            <p class="id-line">ID: {{ b.bookingId }}</p>
+          </div>
+          <div class="card-actions">
+            @if (isConfirmed(b)) {
+              <button
+                type="button"
+                class="btn-download"
+                [disabled]="downloadingId() === b.bookingId"
+                (click)="downloadTicket(b.bookingId)">
+                {{ downloadingId() === b.bookingId ? 'Downloading…' : 'Download PDF' }}
+              </button>
+              @if (canCancel(b)) {
+                <button
+                  type="button"
+                  class="btn-cancel"
+                  [disabled]="cancellingId() === b.bookingId"
+                  (click)="cancelBooking(b)">
+                  {{ cancellingId() === b.bookingId ? 'Cancelling…' : 'Cancel booking' }}
+                </button>
+              } @else {
+                <p class="no-actions">Cancellation closed — showtime has started.</p>
+              }
+            } @else {
+              <p class="no-actions">No actions for this booking.</p>
+            }
+          </div>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/frontend/src/app/pages/my-bookings/my-bookings.component.scss
+++ b/frontend/src/app/pages/my-bookings/my-bookings.component.scss
@@ -1,0 +1,234 @@
+.bookings-page {
+  position: relative;
+  min-height: calc(100vh - 70px);
+  padding: 1.25rem clamp(1rem, 3vw, 2.5rem) 2.5rem;
+  color: #f8fafc;
+}
+
+.bookings-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(124, 58, 237, 0.18), transparent 42%),
+    radial-gradient(circle at 90% 80%, rgba(34, 197, 94, 0.12), transparent 45%),
+    linear-gradient(160deg, #020617 0%, #0f172a 50%, #0b1220 100%);
+  z-index: -1;
+}
+
+.page-nav {
+  margin-bottom: 1rem;
+}
+
+.back-link {
+  color: #93c5fd;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.page-header {
+  margin-bottom: 1.5rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  letter-spacing: -0.02em;
+}
+
+.lede {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.status {
+  color: #cbd5e1;
+}
+
+.status.error {
+  color: #fecaca;
+}
+
+.retry-btn {
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.8);
+  color: #e2e8f0;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.empty-card {
+  max-width: 420px;
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.empty-card p {
+  margin: 0 0 1rem;
+  color: #cbd5e1;
+}
+
+.cta-link {
+  color: #a78bfa;
+  font-weight: 700;
+}
+
+.banner-error {
+  margin: 0 0 1rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  background: rgba(127, 29, 29, 0.35);
+  border: 1px solid rgba(252, 165, 165, 0.35);
+  color: #fecaca;
+}
+
+.booking-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.booking-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+  padding: 1.15rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85));
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.35);
+}
+
+.card-main h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.3;
+}
+
+.title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.status-pill {
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
+.status-pill--confirmed {
+  background: rgba(34, 197, 94, 0.25);
+  color: #86efac;
+}
+
+.status-pill--muted {
+  opacity: 0.9;
+}
+
+.theater-line {
+  margin: 0.25rem 0 0;
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
+.meta-line {
+  margin: 0.35rem 0 0;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.meta-line.subtle {
+  color: #94a3b8;
+  font-size: 0.82rem;
+}
+
+.meta-line .label {
+  color: #94a3b8;
+  margin-right: 0.25rem;
+}
+
+.id-line {
+  margin: 0.65rem 0 0;
+  font-size: 0.78rem;
+  color: #64748b;
+  font-family: ui-monospace, monospace;
+}
+
+.card-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 160px;
+}
+
+.btn-download {
+  padding: 0.55rem 0.85rem;
+  border: 0;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(22, 163, 74, 0.3);
+}
+
+.btn-download:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-cancel {
+  padding: 0.5rem 0.85rem;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(127, 29, 29, 0.25);
+  color: #fecaca;
+}
+
+.btn-cancel:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.no-actions {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+@media (max-width: 720px) {
+  .booking-card {
+    grid-template-columns: 1fr;
+  }
+
+  .card-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    min-width: unset;
+  }
+}

--- a/frontend/src/app/pages/my-bookings/my-bookings.component.ts
+++ b/frontend/src/app/pages/my-bookings/my-bookings.component.ts
@@ -1,0 +1,158 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { BookingService, UserBooking } from '../../services/booking.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-my-bookings',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './my-bookings.component.html',
+  styleUrl: './my-bookings.component.scss'
+})
+export class MyBookingsComponent implements OnInit {
+  bookings = signal<UserBooking[]>([]);
+  loading = signal(true);
+  listError = signal<string | null>(null);
+
+  downloadingId = signal<string | null>(null);
+  downloadError = signal<string | null>(null);
+
+  cancellingId = signal<string | null>(null);
+  cancelError = signal<string | null>(null);
+
+  constructor(
+    private bookingService: BookingService,
+    private toast: ToastService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadBookings();
+  }
+
+  loadBookings(): void {
+    this.loading.set(true);
+    this.listError.set(null);
+    this.bookingService.getMyBookings().subscribe({
+      next: res => {
+        this.bookings.set(res.bookings ?? []);
+        this.loading.set(false);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.loading.set(false);
+        const msg =
+          err.error && typeof err.error === 'object' && typeof err.error.message === 'string'
+            ? err.error.message
+            : null;
+        this.listError.set(msg ?? 'Could not load your bookings. Please try again.');
+      }
+    });
+  }
+
+  isConfirmed(b: UserBooking): boolean {
+    return (b.status ?? '').toUpperCase() === 'CONFIRMED';
+  }
+
+  /** Cancellation is only allowed before the show starts (same rule as the API). */
+  canCancel(b: UserBooking): boolean {
+    if (!this.isConfirmed(b)) {
+      return false;
+    }
+    const raw = b.showTime;
+    if (!raw) {
+      return true;
+    }
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) {
+      return true;
+    }
+    return d.getTime() > Date.now();
+  }
+
+  formatWhen(b: UserBooking): string {
+    const raw = b.showTime;
+    if (!raw) {
+      return '—';
+    }
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) {
+      return raw;
+    }
+    return d.toLocaleString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+  }
+
+  formatConfirmed(b: UserBooking): string {
+    const raw = b.confirmedAt;
+    if (!raw) {
+      return '—';
+    }
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) {
+      return raw;
+    }
+    return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  downloadTicket(bookingId: string): void {
+    if (this.downloadingId()) {
+      return;
+    }
+    this.downloadingId.set(bookingId);
+    this.downloadError.set(null);
+
+    this.bookingService.downloadTicket(bookingId).subscribe({
+      next: blob => {
+        this.downloadingId.set(null);
+        const url = window.URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `ticket_${bookingId}.pdf`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        window.URL.revokeObjectURL(url);
+        this.toast.show('Ticket downloaded');
+      },
+      error: () => {
+        this.downloadingId.set(null);
+        this.downloadError.set('Could not download that ticket. Confirmed bookings only.');
+      }
+    });
+  }
+
+  cancelBooking(booking: UserBooking): void {
+    if (!this.canCancel(booking) || this.cancellingId()) {
+      return;
+    }
+    if (!confirm('Cancel this booking? This cannot be undone.')) {
+      return;
+    }
+    this.cancellingId.set(booking.bookingId);
+    this.cancelError.set(null);
+
+    this.bookingService.cancelBooking(booking.bookingId).subscribe({
+      next: () => {
+        this.cancellingId.set(null);
+        this.toast.show('Booking cancelled');
+        this.loadBookings();
+      },
+      error: (err: HttpErrorResponse) => {
+        this.cancellingId.set(null);
+        const msg =
+          err.error && typeof err.error === 'object' && typeof err.error.message === 'string'
+            ? err.error.message
+            : null;
+        this.cancelError.set(msg ?? 'Could not cancel this booking.');
+      }
+    });
+  }
+}

--- a/frontend/src/app/pages/payment/payment.component.ts
+++ b/frontend/src/app/pages/payment/payment.component.ts
@@ -87,7 +87,6 @@ export class PaymentComponent implements OnInit, OnDestroy {
     this.bookingService
       .checkoutBookingHold({
         holdId,
-        userId: user.id,
         paymentMethod: this.paymentMethod(),
         idempotencyKey: this.newIdempotencyKey()
       })

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { environment } from '../../environments/environment';
 import { Router } from '@angular/router';
 import { vi } from 'vitest';
 import { AuthService, formatAuthHttpError } from './auth.service';
@@ -55,6 +56,7 @@ describe('AuthService', () => {
 
   let service: AuthService;
   let routerNavigate: ReturnType<typeof vi.fn>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     ensureLocalStorage();
@@ -70,6 +72,11 @@ describe('AuthService', () => {
     }).compileComponents();
 
     service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('setSessionFromLogin persists user and updates the signal', () => {
@@ -110,6 +117,10 @@ describe('AuthService', () => {
     globalThis.localStorage.setItem('role', 'admin');
 
     service.logout();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/logout`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ message: 'logout successful' });
 
     expect(globalThis.localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
     expect(globalThis.localStorage.getItem('token')).toBeNull();

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -15,11 +15,19 @@ const USER_STORAGE_KEY = 'auth_user';
 const TOKEN_STORAGE_KEY = 'token';
 
 export function formatAuthHttpError(err: unknown): string {
-  if (err instanceof HttpErrorResponse && err.error && typeof err.error === 'object') {
-    const e = err.error as { message?: string; fields?: Record<string, string> };
-    const fieldText = e.fields ? Object.values(e.fields).join(' ') : '';
-    if (e.message || fieldText) {
-      return [e.message, fieldText].filter(Boolean).join(' ');
+  if (err instanceof HttpErrorResponse) {
+    if (err.status === 0) {
+      return 'Cannot reach the server. Is the API running on port 8080?';
+    }
+    if (err.error && typeof err.error === 'object' && !Array.isArray(err.error)) {
+      const e = err.error as { message?: string; fields?: Record<string, string> };
+      const fieldText = e.fields ? Object.values(e.fields).join(' ') : '';
+      if (e.message || fieldText) {
+        return [e.message, fieldText].filter(Boolean).join(' ');
+      }
+    }
+    if (typeof err.error === 'string' && err.error.trim()) {
+      return err.error.trim();
     }
   }
   if (err instanceof Error) {
@@ -73,13 +81,27 @@ export class AuthService {
     this.token.set(res.accessToken);
   }
 
+  /** Clears local session; revokes token on the server when possible. */
   logout() {
-    localStorage.removeItem(USER_STORAGE_KEY);
-    localStorage.removeItem(TOKEN_STORAGE_KEY);
-    localStorage.removeItem('role');
-    this.user.set(null);
-    this.token.set(null);
-    this.router.navigate(['/login']);
+    const finish = () => {
+      localStorage.removeItem(USER_STORAGE_KEY);
+      localStorage.removeItem(TOKEN_STORAGE_KEY);
+      localStorage.removeItem('role');
+      this.user.set(null);
+      this.token.set(null);
+      void this.router.navigate(['/login']);
+    };
+
+    const token = this.readStoredToken();
+    if (!token) {
+      finish();
+      return;
+    }
+
+    this.http.post<{ message: string }>(`${environment.apiUrl}/auth/logout`, {}).subscribe({
+      next: () => finish(),
+      error: () => finish()
+    });
   }
 
   isLoggedIn(): boolean {

--- a/frontend/src/app/services/booking.service.ts
+++ b/frontend/src/app/services/booking.service.ts
@@ -1,24 +1,38 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../../environments/environment';
+
+/** Matches GET /bookings list items from the API. */
+export interface UserBooking {
+  bookingId: string;
+  holdId: string;
+  userId: string;
+  showtimeId: string;
+  seatNumbers: string[];
+  status: string;
+  totalAmount: number;
+  confirmedAt: string;
+  movieTitle: string;
+  theaterName: string;
+  city: string;
+  screenName: string;
+  showTime: string;
+  language: string;
+  format: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class BookingService {
   constructor(private http: HttpClient) {}
 
-  createBookingHold(data: { userId: string; showtimeId: string; seatNumbers: string[] }) {
+  createBookingHold(data: { showtimeId: string; seatNumbers: string[] }) {
     return this.http.post<{ message: string; hold: { holdId: string; holdExpiresAt: string; totalAmount: number } }>(
       `${environment.apiUrl}/bookings/holds`,
       data
     );
   }
 
-  checkoutBookingHold(data: {
-    holdId: string;
-    userId: string;
-    paymentMethod: string;
-    idempotencyKey: string;
-  }) {
+  checkoutBookingHold(data: { holdId: string; paymentMethod: string; idempotencyKey: string }) {
     return this.http.post<{
       message: string;
       booking: { bookingId: string; holdId: string; totalAmount: number; seatNumbers: string[]; status: string };
@@ -29,26 +43,16 @@ export class BookingService {
     return this.http.delete<{ message: string }>(`${environment.apiUrl}/bookings/holds/${holdId}`);
   }
 
-  getSeats(showId: string) {
-    return this.http.get(`${environment.apiUrl}/shows/${showId}/seats`);
-  }
-
-  createBooking(data: any) {
-    return this.http.post(`${environment.apiUrl}/bookings`, data);
-  }
-
   getMyBookings() {
-    return this.http.get(`${environment.apiUrl}/bookings/me`);
+    return this.http.get<{ bookings: UserBooking[] }>(`${environment.apiUrl}/bookings`);
   }
 
-  cancelBooking(id: string) {
-    return this.http.post(`${environment.apiUrl}/bookings/${id}/cancel`, {});
+  cancelBooking(bookingId: string) {
+    const params = new HttpParams().set('bookingId', bookingId);
+    return this.http.delete<{ message: string }>(`${environment.apiUrl}/bookings`, { params });
   }
 
   downloadTicket(id: string) {
-    return this.http.get(
-      `${environment.apiUrl}/bookings/${id}/ticket`,
-      { responseType: 'blob' }
-    );
+    return this.http.get(`${environment.apiUrl}/bookings/${id}/ticket`, { responseType: 'blob' });
   }
 }

--- a/frontend/src/app/services/toast.service.ts
+++ b/frontend/src/app/services/toast.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  readonly message = signal<string | null>(null);
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Shows a short-lived message (e.g. success feedback). */
+  show(text: string, durationMs = 4000): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.message.set(text);
+    this.timer = setTimeout(() => {
+      this.message.set(null);
+      this.timer = null;
+    }, durationMs);
+  }
+}


### PR DESCRIPTION
Adds My Bookings (/bookings), aligns the app with the booking/auth APIs, improves auth UX, and enforces cancel / hold only before showtime (UI + API). Includes small signup validation and catalog/poster fixes on the backend.

Frontend
My Bookings: list user bookings, PDF download success feedback, cancel with confirmation; cancel hidden/disabled after showtime.
Routing: /bookings behind auth guard; header link + active state.
Booking service: GET /bookings, DELETE /bookings?bookingId=; hold/checkout payloads aligned (no userId in body).
Auth: clearer HTTP errors (incl. network/status === 0); logout calls POST /auth/logout then clears client storage; signup phone normalization/validators; login redirect for from=bookings → /bookings.
Home: “See All” works when logged in (expand catalog / show less).
Backend
Showtimes: listings exclude past start times where applicable.
Hold / cancel: reject when showtime has already started (400 with clear error).
Signup: normalized phone (digit length rules), name length; tests updated.
Posters / seed: corrected poster URLs for seeded movies.

How to test
Sign up / log in → open My Bookings → confirm list loads.
Download ticket PDF → expect success toast.
Cancel a future booking → success toast; after showtime, cancel should not be offered / should fail from API if forced.
Try hold/checkout for a past showtime → expect API error.